### PR TITLE
Update Utils.php

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -182,6 +182,7 @@ final class Utils
      * @param array  $rawHeaders The headers from the HTTP request
      * @param array  $cookies    The cookies from the HTTP request
      * @param string $rawBody    The raw HTTP request payload
+     * @param string $isOnline   The type of auth access token  
      *
      * @return HttpResponse
      * @throws \Psr\Http\Client\ClientExceptionInterface
@@ -190,9 +191,9 @@ final class Utils
      * @throws \Shopify\Exception\SessionNotFoundException
      * @throws \Shopify\Exception\UninitializedContextException
      */
-    public static function graphqlProxy(array $rawHeaders, array $cookies, string $rawBody): HttpResponse
+    public static function graphqlProxy(array $rawHeaders, array $cookies, string $rawBody, bool $isOnline=true): HttpResponse
     {
-        $session = self::loadCurrentSession($rawHeaders, $cookies, true);
+        $session = self::loadCurrentSession($rawHeaders, $cookies, $isOnline);
         if (!$session) {
             throw new SessionNotFoundException("Could not find session for GraphQL proxy");
         }


### PR DESCRIPTION
Fixed GraphQl throwing error `Could not find session for GraphQL proxy` if we are using offline session.


## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [X] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
